### PR TITLE
Preserve tool-call JSON for deterministic local inference

### DIFF
--- a/mini_agent/schema/schema.py
+++ b/mini_agent/schema/schema.py
@@ -15,7 +15,8 @@ class FunctionCall(BaseModel):
     """Function call details."""
 
     name: str
-    arguments: dict[str, Any]  # Function arguments as dict
+    arguments: dict[str, Any]  # Parsed function arguments
+    arguments_json: str | None = None  # Raw JSON string (for deterministic replay)
 
 
 class ToolCall(BaseModel):


### PR DESCRIPTION
## Summary
- add `arguments_json` to `FunctionCall` so we persist the exact tool-call payload returned by the model
- have the OpenAI client reuse the stored JSON when constructing follow-up requests (falling back to a canonical dump only if the string is missing)
- capture the raw JSON when parsing responses, keeping both the parsed dict (for tool execution) and the untouched string (for replay)

## Problem
When Mini-Agent is configured to send requests to a local LM Studio endpoint (or any local serving stack with KV cache), each subsequent request must be byte-identical for the cached portion of the context. Today the request builder re-serializes every tool call in the transcript using `json.dumps(..., sort_keys=True)`. That changes key ordering, whitespace, or float formatting compared to what the model actually emitted, meaning the tool call that was prepended to Request #2 is different from the one the model saw during Request #1. LM Studio therefore treats the assistant history as a cache miss, reprocessing all prior tokens (~12k tokens per turn in our setup), wasting latency and compute.

## Testing
- python - <<'PY' … (arguments_json present) ✅
- python - <<'PY' … (fallback path) ✅
- Manual: local LM Studio run now reports 99.88% prompt reuse on Request #2 (previously ~33%).
