### PR TITLE
Fix: Add missing Authorization header for MiniMax API

### DIFF
--- a/mini_agent/llm/anthropic_client.py
+++ b/mini_agent/llm/anthropic_client.py
@@ -42,6 +42,7 @@ class AnthropicClient(LLMClientBase):
         self.client = anthropic.AsyncAnthropic(
             base_url=api_base,
             api_key=api_key,
+            default_headers={"Authorization": f"Bearer {api_key}"},
         )
 
     async def _make_api_request(


### PR DESCRIPTION
## Summary
This PR fixes a `401 Authentication Error` when running the agent with the MiniMax API.

## The Bug
When running `mini-agent cli` on Windows 11 / Powershell, the API returned the following error:
> "login fail: Please carry the API secret key in the 'Authorization' field of the request header"

It appears the MiniMax API endpoint requires the API key in the `Authorization` header (`Bearer <key>`), but the Anthropic client was not sending it by default.

## The Fix
Updated mini_agent/llm/anthropic_client.py to explicitly add the `Authorization` header during client initialization.

## Verification
Verified that the CLI agent now interacts successfully with the API without authentication errors.