### PR TITLE
feat(skill): inject skill root directory path into prompt

### DIFF
--- a/mini_agent/tools/skill_loader.py
+++ b/mini_agent/tools/skill_loader.py
@@ -26,10 +26,17 @@ class Skill:
 
     def to_prompt(self) -> str:
         """Convert skill to prompt format"""
+        # Inject skill root directory path for context
+        skill_root = str(self.skill_path.parent) if self.skill_path else "unknown"
+
         return f"""
 # Skill: {self.name}
 
 {self.description}
+
+**Skill Root Directory:** `{skill_root}`
+
+All files and references in this skill are relative to this directory.
 
 ---
 

--- a/tests/test_skill_loader.py
+++ b/tests/test_skill_loader.py
@@ -244,3 +244,31 @@ Run the script: python scripts/test_script.py
 
         # Check that script path is converted to absolute
         assert str(skill_dir / "scripts" / "test_script.py") in skill.content
+
+
+def test_skill_to_prompt_includes_root_directory():
+    """Test that to_prompt includes skill root directory path"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        skill_dir = Path(tmpdir) / "test-skill"
+        skill_dir.mkdir()
+
+        skill_file = skill_dir / "SKILL.md"
+        skill_content = """---
+name: test-skill
+description: A test skill
+---
+
+Skill content here.
+"""
+        skill_file.write_text(skill_content, encoding="utf-8")
+
+        loader = SkillLoader(tmpdir)
+        skill = loader.load_skill(skill_file)
+
+        assert skill is not None
+
+        # Test to_prompt includes root directory
+        prompt = skill.to_prompt()
+        assert "Skill Root Directory" in prompt
+        assert str(skill_dir) in prompt
+        assert "All files and references in this skill are relative to this directory" in prompt


### PR DESCRIPTION
## Summary
- Inject the absolute path of the skill root directory into the prompt when loading a skill
- Allows AI to always know the base location of skill files
- Helps debug path issues even when skill authors mix absolute/relative paths
- Enables use of find/glob tools to locate files dynamically

## Background
The previous approach of only converting specific directory patterns (`scripts/`, `references/`, etc.) was too limited:
- It didn't account for the variety of ways skill authors might structure their content
- Skill authors may use non-standard directory names
- Absolute/relative path confusion could still break skill loading

By injecting the skill root directory path directly into the prompt, AI agents can:
1. Always know where the skill files are located
2. Debug path issues independently
3. Use tools like `find` or `glob` to locate files dynamically

## Test plan
- [x] All existing tests pass
- [x] Added new test `test_skill_to_prompt_includes_root_directory`