### PR TITLE
fix(skill): align path patterns with Agent Skills specification

### DIFF
--- a/mini_agent/tools/skill_loader.py
+++ b/mini_agent/tools/skill_loader.py
@@ -125,7 +125,8 @@ class SkillLoader:
         """
         import re
 
-        # Pattern 1: Directory-based paths (scripts/, examples/, templates/, reference/)
+        # Pattern 1: Directory-based paths (scripts/, references/, assets/)
+        # See https://agentskills.io/specification#optional-directories
         def replace_dir_path(match):
             prefix = match.group(1)  # e.g., "python " or "`"
             rel_path = match.group(2)  # e.g., "scripts/with_server.py"
@@ -135,7 +136,7 @@ class SkillLoader:
                 return f"{prefix}{abs_path}"
             return match.group(0)
 
-        pattern_dirs = r"(python\s+|`)((?:scripts|examples|templates|reference)/[^\s`\)]+)"
+        pattern_dirs = r"(python\s+|`)((?:scripts|references|assets)/[^\s`\)]+)"
         content = re.sub(pattern_dirs, replace_dir_path, content)
 
         # Pattern 2: Direct markdown/document references (forms.md, reference.md, etc.)


### PR DESCRIPTION
## Summary
- Update directory path patterns to match the official Agent Skills specification
- Replace \`reference/\` with \`references/\` (plural, as per spec)
- Remove \`examples/\` and \`templates/\` (not in spec)
- Add \`assets/\` (defined in spec)

## Background
The Agent Skills specification at https://agentskills.io/specification#optional-directories defines three optional directories:
- **scripts/** - Contains executable code
- **references/** - Contains additional documentation  
- **assets/** - Contains static resources (templates, images, data files)

The previous code used non-standard directory names:
- \`reference/\` (singular) instead of \`references/\` (plural)
- \`examples/\` and \`templates/\` (not defined in specification)
- Missing \`assets/\` (defined in specification)

This caused path conversion to fail for skills following the official specification.

## Test plan
- [x] All existing tests pass