### PR TITLE
docs: Fix broken documentation links in README files

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,7 +333,7 @@ This project is licensed under the [MIT License](LICENSE).
 
 ## References
 
-- MiniMax API: https://platform.minimaxi.com/document
+- MiniMax API: https://platform.minimax.io/docs
 - MiniMax-M2: https://github.com/MiniMax-AI/MiniMax-M2
 - Anthropic API: https://docs.anthropic.com/claude/reference
 - Claude Skills: https://github.com/anthropics/skills

--- a/README_CN.md
+++ b/README_CN.md
@@ -313,7 +313,7 @@ python -m mini_agent.cli
 ## 相关文档
 
 - [开发指南](docs/DEVELOPMENT_GUIDE_CN.md) - 详细的开发和配置指引
-- [生产环境指南](docs/PRODUCTION_DEPLOYMENT_GUIDE_CN.md) - 生产部署最佳实践
+- [生产环境指南](docs/PRODUCTION_GUIDE_CN.md) - 生产部署最佳实践
 
 ## 社区
 
@@ -334,7 +334,7 @@ python -m mini_agent.cli
 
 ## 参考资源
 
-- MiniMax API: https://platform.minimaxi.com/document
+- MiniMax API: https://platform.minimaxi.com/docs
 - MiniMax-M2: https://github.com/MiniMax-AI/MiniMax-M2
 - Anthropic API: https://docs.anthropic.com/claude/reference
 - Claude Skills: https://github.com/anthropics/skills


### PR DESCRIPTION
# Fix broken documentation links in README files

## 📝 Description

This PR fixes broken and incorrect documentation links in both English and Chinese README files.

## 🔧 Changes

### README.md
- Fixed MiniMax API reference link from `https://platform.minimaxi.com/document` to `https://platform.minimax.io/docs` (correct global platform URL)

### README_CN.md
- Fixed production guide link from `docs/PRODUCTION_DEPLOYMENT_GUIDE_CN.md` to `docs/PRODUCTION_GUIDE_CN.md` (correct filename)
- Fixed MiniMax API reference link from `https://platform.minimaxi.com/document` to `https://platform.minimaxi.com/docs` (correct path)

## 🎯 Impact

- Users following the documentation links will now reach the correct resources
- Improved documentation accuracy and user experience
- Ensures consistency between English and Chinese documentation

## ✅ Testing

- Verified all referenced files exist in the repository
- Confirmed URLs are accessible and correct

## 📋 Checklist

- [x] Documentation links verified
- [x] Both English and Chinese versions updated
- [x] No breaking changes
