### PR TITLE
Switch to defusedxml for secure XML parsing in skills and evaluation harness

### DIFF
--- a/mini_agent/skills/document-skills/docx/ooxml/scripts/validation/redlining.py
+++ b/mini_agent/skills/document-skills/docx/ooxml/scripts/validation/redlining.py
@@ -29,7 +29,7 @@ class RedliningValidator:
 
         # First, check if there are any tracked changes by Claude to validate
         try:
-            import xml.etree.ElementTree as ET
+            import defusedxml.ElementTree as ET
 
             tree = ET.parse(modified_file)
             root = tree.getroot()
@@ -81,7 +81,7 @@ class RedliningValidator:
 
             # Parse both XML files using xml.etree.ElementTree for redlining validation
             try:
-                import xml.etree.ElementTree as ET
+                import defusedxml.ElementTree as ET
 
                 modified_tree = ET.parse(modified_file)
                 modified_root = modified_tree.getroot()

--- a/mini_agent/skills/document-skills/pptx/ooxml/scripts/validation/redlining.py
+++ b/mini_agent/skills/document-skills/pptx/ooxml/scripts/validation/redlining.py
@@ -29,7 +29,7 @@ class RedliningValidator:
 
         # First, check if there are any tracked changes by Claude to validate
         try:
-            import xml.etree.ElementTree as ET
+            import defusedxml.ElementTree as ET
 
             tree = ET.parse(modified_file)
             root = tree.getroot()
@@ -79,9 +79,9 @@ class RedliningValidator:
                 )
                 return False
 
-            # Parse both XML files using xml.etree.ElementTree for redlining validation
+            # Parse both XML files using defusedxml for redlining validation
             try:
-                import xml.etree.ElementTree as ET
+                import defusedxml.ElementTree as ET
 
                 modified_tree = ET.parse(modified_file)
                 modified_root = modified_tree.getroot()

--- a/mini_agent/skills/mcp-builder/scripts/evaluation.py
+++ b/mini_agent/skills/mcp-builder/scripts/evaluation.py
@@ -10,7 +10,7 @@ import re
 import sys
 import time
 import traceback
-import xml.etree.ElementTree as ET
+import defusedxml.ElementTree as ET
 from pathlib import Path
 from typing import Any
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "pipx>=1.8.0",
     "anthropic>=0.39.0",
     "openai>=1.57.4",
+    "defusedxml>=0.7.1",
     "agent-client-protocol>=0.6.0",
 ]
 


### PR DESCRIPTION
The current implementation uses the standard `xml.etree.ElementTree` to parse XML files from untrusted sources, such as Office documents (OOXML) processed by skills and user-provided evaluation files. This poses a potential risk for XML External Entity (XXE) attacks.

I noticed these vulnerable patterns while reviewing the codebase and decided to switch to `defusedxml`, which provides a secure drop-in replacement. 

**Changes:**
- Added `defusedxml` to project dependencies in `pyproject.toml`.
- Updated `mini_agent/skills/mcp-builder/scripts/evaluation.py` to use `defusedxml.etree.ElementTree`.
- Secured OOXML validation logic in `redlining.py` for both DOCX and PPTX skills by replacing lazy imports with the secure alternative.
- Maintained all existing business logic and parsing behavior to ensure no regressions in functionality.

These improvements ensure the agent can safely handle malformed or malicious XML documents without compromising the underlying system.