### PR TITLE
[codex] fix mcp exit cleanup

### DIFF
--- a/mini_agent/tools/mcp_loader.py
+++ b/mini_agent/tools/mcp_loader.py
@@ -16,6 +16,7 @@ from .base import Tool, ToolResult
 
 # Connection type aliases
 ConnectionType = Literal["stdio", "sse", "http", "streamable_http"]
+DISCONNECT_TIMEOUT_SECONDS = 5.0
 
 
 @dataclass
@@ -155,6 +156,10 @@ class MCPServerConnection:
         self.session: ClientSession | None = None
         self.exit_stack: AsyncExitStack | None = None
         self.tools: list[MCPTool] = []
+        self._shutdown_event: asyncio.Event | None = None
+        self._connected_event: asyncio.Event | None = None
+        self._lifecycle_task: asyncio.Task[None] | None = None
+        self._connected = False
 
     def _get_connect_timeout(self) -> float:
         """Get effective connect timeout."""
@@ -170,6 +175,22 @@ class MCPServerConnection:
 
     async def connect(self) -> bool:
         """Connect to the MCP server with timeout protection."""
+        if self._lifecycle_task and not self._lifecycle_task.done():
+            return self._connected
+
+        self.tools = []
+        self.session = None
+        self.exit_stack = None
+        self._connected = False
+        self._shutdown_event = asyncio.Event()
+        self._connected_event = asyncio.Event()
+        self._lifecycle_task = asyncio.create_task(self._connection_lifecycle())
+
+        await self._connected_event.wait()
+        return self._connected
+
+    async def _connection_lifecycle(self) -> None:
+        """Own the MCP transport lifecycle in a single task."""
         connect_timeout = self._get_connect_timeout()
 
         try:
@@ -207,29 +228,50 @@ class MCPServerConnection:
                 )
                 self.tools.append(mcp_tool)
 
+            self._connected = True
             conn_info = self.url if self.url else self.command
             print(f"✓ Connected to MCP server '{self.name}' ({self.connection_type}: {conn_info}) - loaded {len(self.tools)} tools")
             for tool in self.tools:
                 desc = tool.description[:60] if len(tool.description) > 60 else tool.description
                 print(f"  - {tool.name}: {desc}...")
-            return True
+
+            if self._connected_event and not self._connected_event.is_set():
+                self._connected_event.set()
+
+            if self._shutdown_event:
+                await self._shutdown_event.wait()
 
         except TimeoutError:
             print(f"✗ Connection to MCP server '{self.name}' timed out after {connect_timeout}s")
-            if self.exit_stack:
-                await self.exit_stack.aclose()
-                self.exit_stack = None
-            return False
+            if self._connected_event and not self._connected_event.is_set():
+                self._connected_event.set()
+
+        except asyncio.CancelledError:
+            if self._connected_event and not self._connected_event.is_set():
+                self._connected_event.set()
+            raise
 
         except Exception as e:
             print(f"✗ Failed to connect to MCP server '{self.name}': {e}")
-            if self.exit_stack:
-                await self.exit_stack.aclose()
-                self.exit_stack = None
+            if self._connected_event and not self._connected_event.is_set():
+                self._connected_event.set()
             import traceback
 
             traceback.print_exc()
-            return False
+
+        finally:
+            stack = self.exit_stack
+            self.exit_stack = None
+            self.session = None
+
+            try:
+                if stack:
+                    await stack.aclose()
+            finally:
+                self._connected = False
+                self._shutdown_event = None
+                if self._connected_event and not self._connected_event.is_set():
+                    self._connected_event.set()
 
     async def _connect_stdio(self):
         """Connect via STDIO transport."""
@@ -268,10 +310,23 @@ class MCPServerConnection:
 
     async def disconnect(self):
         """Properly disconnect from the MCP server."""
-        if self.exit_stack:
-            await self.exit_stack.aclose()
-            self.exit_stack = None
-            self.session = None
+        lifecycle_task = self._lifecycle_task
+        if not lifecycle_task:
+            return
+
+        if self._shutdown_event and not self._shutdown_event.is_set():
+            self._shutdown_event.set()
+
+        try:
+            await asyncio.wait_for(lifecycle_task, timeout=DISCONNECT_TIMEOUT_SECONDS)
+        except TimeoutError:
+            print(
+                f"✗ Timed out while disconnecting MCP server '{self.name}' after "
+                f"{DISCONNECT_TIMEOUT_SECONDS}s"
+            )
+        finally:
+            if self._lifecycle_task is lifecycle_task:
+                self._lifecycle_task = None
 
 
 # Global connections registry
@@ -421,6 +476,9 @@ async def load_mcp_tools_async(config_path: str = "mcp.json") -> list[Tool]:
 async def cleanup_mcp_connections():
     """Clean up all MCP connections."""
     global _mcp_connections
-    for connection in _mcp_connections:
-        await connection.disconnect()
+    for connection in list(_mcp_connections):
+        try:
+            await connection.disconnect()
+        except Exception as e:
+            print(f"✗ Error cleaning up MCP server '{connection.name}': {e}")
     _mcp_connections.clear()

--- a/notes/01_basic_tools_explain.md
+++ b/notes/01_basic_tools_explain.md
@@ -1,0 +1,63 @@
+# 01_basic_tools.py 说明
+
+下面是 `examples/01_basic_tools.py` 里每个函数的详细说明（含关键步骤与行为），按函数顺序说明。
+
+## demo_write_tool()
+- 目的：演示 `WriteTool` 如何创建一个新文件并写入内容。
+- 关键流程：
+  - 打印分隔线和标题，标识 Demo 1。
+  - 使用 `tempfile.TemporaryDirectory()` 创建临时目录，退出 `with` 块时自动清理。
+  - 组装临时文件路径 `hello.txt`。
+  - 初始化 `WriteTool()`，调用 `await tool.execute(path=..., content=...)` 写入内容。
+  - 根据 `result.success` 判断：
+    - 成功：打印创建路径与文件内容。
+    - 失败：打印 `result.error`。
+- 重点：展示“用工具写文件 + 验证写入结果”的完整流程。
+
+## demo_read_tool()
+- 目的：演示 `ReadTool` 如何读取文件内容。
+- 关键流程：
+  - 打印分隔线和标题，标识 Demo 2。
+  - 用 `tempfile.NamedTemporaryFile(..., delete=False)` 创建临时文件并写入三行文本。
+  - 通过 `ReadTool().execute(path=...)` 读取内容。
+  - 成功打印 `result.content`，失败打印 `result.error`。
+  - `finally` 中删除临时文件，避免残留。
+- 重点：展示“读文件 + 成功/失败分支 + 资源清理”的标准用法。
+
+## demo_edit_tool()
+- 目的：演示 `EditTool` 如何在已有文件中替换文本。
+- 关键流程：
+  - 打印分隔线和标题，标识 Demo 3。
+  - 创建临时文件并写入两行包含 `Python` 的文本。
+  - 打印原始内容。
+  - 调用 `EditTool().execute(path=..., old_str="Python", new_str="Agent")` 进行替换。
+  - 成功打印替换后内容，失败打印 `result.error`。
+  - `finally` 删除临时文件。
+- 重点：展示“替换文本”的最小流程与前后对比。
+
+## demo_bash_tool()
+- 目的：演示 `BashTool` 执行系统命令。
+- 关键流程：
+  - 打印分隔线和标题，标识 Demo 4。
+  - 初始化 `BashTool()`。
+  - 依次执行三条命令并检查 `result.success`：
+    - `ls -la`：列出目录文件（输出截取前 200 个字符）。
+    - `pwd`：输出当前工作目录。
+    - `echo 'Hello from BashTool!'`：输出一行文本。
+- 重点：展示“执行命令 + 判断成功 + 读取输出”的模式。
+
+## main()
+- 目的：串联并依次执行所有 demo。
+- 关键流程：
+  - 打印整体标题与说明。
+  - 依次 `await` 调用四个 demo：
+    - `demo_write_tool()`
+    - `demo_read_tool()`
+    - `demo_edit_tool()`
+    - `demo_bash_tool()`
+  - 打印“全部完成”的结束提示。
+- 重点：这是异步入口，用于统一运行全部示例。
+
+## if __name__ == "__main__":
+- 目的：确保脚本被直接运行时才执行 demo。
+- 行为：调用 `asyncio.run(main())` 启动异步主函数。

--- a/notes/02_simple_agent_explain.md
+++ b/notes/02_simple_agent_explain.md
@@ -1,0 +1,132 @@
+# 02_simple_agent.py 逐函数说明
+
+本文说明文件：`/Users/kirineko/papers/agent_paper/Mini-Agent/examples/02_simple_agent.py`
+
+这个示例的核心目标是：演示如何把 `LLMClient + Agent + Tools` 组装起来，让 Agent 根据自然语言任务自动选择并调用工具完成工作。
+
+## 模块级内容
+
+- `import asyncio`：用于运行异步入口函数 `main()`。
+- `import tempfile`：创建临时工作目录，避免污染项目目录。
+- `from pathlib import Path`：处理文件路径（检查存在、读文件、拼路径等）。
+- `from mini_agent import LLMClient`：创建 LLM 调用客户端。
+- `from mini_agent.agent import Agent`：Agent 主体，负责多步推理和工具调用。
+- `from mini_agent.config import Config`：读取 YAML 配置（模型、API key、base URL）。
+- `from mini_agent.tools import BashTool, EditTool, ReadTool, WriteTool`：给 Agent 的工具集。
+
+---
+
+## `async def demo_file_creation()`
+
+函数职责：演示“Agent 驱动的文件创建任务”。
+
+执行流程：
+1. 打印标题区块，说明当前是文件创建 Demo。
+2. 定位配置文件 `mini_agent/config/config.yaml`。
+3. 如果配置文件不存在：
+   - 打印错误提示；
+   - 提示用户从 `config-example.yaml` 复制；
+   - `return` 提前结束。
+4. 读取配置：`config = Config.from_yaml(config_path)`。
+5. 校验 API Key：
+   - 条件是 key 为空，或以 `YOUR_` 开头（示例占位符）；
+   - 不合法则提示并 `return`。
+6. 创建临时工作区：`with tempfile.TemporaryDirectory() as workspace_dir`。
+   - 这是整个 Agent 实际读写的目录。
+7. 加载系统提示词 `mini_agent/config/system_prompt.md`：
+   - 文件存在则读取 UTF-8 文本；
+   - 不存在则使用默认提示词 `You are a helpful AI assistant that can use tools.`。
+8. 初始化 LLM 客户端：
+   - `api_key / api_base / model` 都来自配置。
+9. 初始化工具列表：
+   - `ReadTool(workspace_dir=workspace_dir)`：限制读取范围到临时工作区；
+   - `WriteTool(workspace_dir=workspace_dir)`：限制写入范围到临时工作区；
+   - `EditTool(workspace_dir=workspace_dir)`：限制编辑范围到临时工作区；
+   - `BashTool()`：执行 bash 命令。
+10. 创建 Agent：
+   - 传入 `llm_client`、`system_prompt`、`tools`；
+   - `max_steps=10` 限制最多推理/工具调用步数；
+   - `workspace_dir` 提供工作目录上下文。
+11. 定义任务 `task`：让 Agent 创建 `hello.py`，包含 `greet(name)` 并调用。
+12. 打印任务文本，然后 `agent.add_user_message(task)` 把任务加入对话。
+13. `result = await agent.run()`：启动 Agent 执行。
+14. 成功时：
+   - 打印 Agent 的最终回复；
+   - 检查 `hello.py` 是否存在；
+   - 存在则打印文件内容，不存在则提示“可能用了不同完成方式”。
+15. 异常时：
+   - 捕获异常并打印；
+   - `traceback.print_exc()` 输出完整堆栈方便排错。
+
+这个函数体现的设计点：
+- 先做配置与凭据前置校验，避免无效调用。
+- 用临时目录隔离运行副作用。
+- 让 Agent 决定工具使用顺序，人只给任务目标。
+
+---
+
+## `async def demo_bash_task()`
+
+函数职责：演示“Agent 驱动的 bash 信息收集任务”。
+
+执行流程：
+1. 打印标题区块，说明当前是 Bash Demo。
+2. 检查 `config.yaml` 是否存在，不存在直接返回。
+3. 读取配置并校验 API key；不合法直接返回。
+4. 创建临时工作目录并打印路径。
+5. 同样读取系统提示词文件，不存在则回退默认提示词。
+6. 初始化 `LLMClient`。
+7. 初始化工具列表（与上个函数不同点）：
+   - 使用 `ReadTool`、`WriteTool`、`BashTool`；
+   - 这里没有放 `EditTool`，因为任务是命令执行与结果汇总，不强调文本替换。
+8. 创建 `Agent`（同样 `max_steps=10`）。
+9. 定义任务 `task`：
+   - 显示当前日期时间；
+   - 列出当前目录所有 Python 文件；
+   - 统计 Python 文件数量。
+10. 把任务加入消息后调用 `await agent.run()`。
+11. 成功时打印 Agent 回答；异常时打印错误。
+
+这个函数体现的设计点：
+- Agent 可用于“命令编排 + 结果解释”场景。
+- 工具最小化按任务裁剪，不必每次挂全部工具。
+
+---
+
+## `async def main()`
+
+函数职责：统一编排示例运行顺序。
+
+执行流程：
+1. 打印总标题与说明（强调 Agent 通过 LLM 决定工具调用）。
+2. 顺序执行：
+   - `await demo_file_creation()`
+   - 打印两个空行分隔
+   - `await demo_bash_task()`
+3. 打印“全部完成”提示。
+
+关键点：
+- `main()` 只负责流程编排，不承担具体业务逻辑。
+- 两个 demo 都是异步函数，所以用 `await` 串行执行。
+
+---
+
+## `if __name__ == "__main__":`
+
+函数职责：脚本入口保护。
+
+执行流程：
+1. 当文件被“直接运行”时执行下面代码；
+2. `asyncio.run(main())` 启动事件循环并运行 `main()`。
+
+关键点：
+- 如果此文件被其他模块 `import`，不会自动执行 demo。
+
+---
+
+## 补充理解：这个示例整体在演示什么
+
+1. Agent 的标准装配顺序：`Config -> LLMClient -> Tools -> Agent -> add_user_message -> run`。
+2. 工具权限边界：通过 `workspace_dir` 把文件工具限制在临时目录。
+3. 任务表达方式：给目标和约束，不给具体命令，让 Agent 自主规划。
+4. 最小可运行闭环：配置检查、任务执行、结果打印、异常处理都具备。

--- a/notes/03_session_notes_explain.md
+++ b/notes/03_session_notes_explain.md
@@ -1,0 +1,132 @@
+# 03_session_notes.py 逐函数详细说明
+
+本文对应源码：`/Users/kirineko/papers/agent_paper/Mini-Agent/examples/03_session_notes.py`
+
+这个示例的目标是展示 Session Note（会话记忆）工具如何工作，包括：
+- 直接调用工具进行记录与回忆。
+- 在 Agent 场景中跨会话保留上下文。
+
+## 模块级结构
+
+- `asyncio`：用于运行异步入口函数。
+- `json`：用于读取和格式化记忆文件内容。
+- `tempfile`：创建临时文件和临时目录，避免污染项目目录。
+- `Path`：路径处理和文件读写。
+- `LLMClient`：调用模型的客户端。
+- `Agent`：负责多步推理和工具调用。
+- `Config`：从 YAML 加载模型配置和 API 信息。
+- `BashTool, ReadTool, WriteTool`：通用工具。
+- `SessionNoteTool, RecallNoteTool`：会话记忆核心工具。
+
+---
+
+## `async def demo_direct_note_usage()`
+
+函数职责：不经过 Agent，直接演示记忆工具的最小闭环。
+
+执行流程：
+1. 打印 Demo 标题。
+2. 使用 `tempfile.NamedTemporaryFile(..., delete=False, suffix=".json")` 创建临时记忆文件，拿到 `note_file` 路径。
+3. 在 `try` 块中初始化两个工具：
+   - `record_tool = SessionNoteTool(memory_file=note_file)`
+   - `recall_tool = RecallNoteTool(memory_file=note_file)`
+4. 连续调用 `record_tool.execute(...)` 写入三条结构化记忆：
+   - 用户背景（`user_info`）
+   - 项目信息（`project_info`）
+   - 用户偏好（`user_preference`）
+5. 调用 `recall_tool.execute()`：不带过滤条件，回忆全部记忆。
+6. 调用 `recall_tool.execute(category="user_preference")`：按类别过滤，只回忆偏好类。
+7. 直接读取 JSON 记忆文件并 `json.dumps(..., indent=2, ensure_ascii=False)` 打印，便于观察底层存储格式。
+8. 在 `finally` 中 `Path(note_file).unlink(missing_ok=True)` 删除临时文件，保证清理。
+
+这个函数验证了三件事：
+- 记忆可写入。
+- 记忆可全量回忆。
+- 记忆可按类别检索。
+
+---
+
+## `async def demo_agent_with_notes()`
+
+函数职责：演示 Agent 如何借助 Session Note 实现跨会话记忆。
+
+执行流程（前置阶段）：
+1. 打印 Demo 标题。
+2. 检查 `mini_agent/config/config.yaml` 是否存在；不存在就退出。
+3. 加载 `Config.from_yaml(...)`。
+4. 校验 API key 是否有效（空值或占位符 `YOUR_` 视为无效）。
+5. 创建临时工作目录 `workspace_dir`，整个示例在该目录运行。
+6. 加载系统提示词 `mini_agent/config/system_prompt.md`，不存在则回退默认提示词。
+7. 追加 `note_instructions` 到 `system_prompt`，明确告诉模型如何使用：
+   - `record_note` 保存重要信息。
+   - `recall_notes` 恢复历史上下文。
+   - 推荐类别如 `user_info / user_preference / project_info / decision`。
+8. 初始化 `LLMClient`。
+9. 定义记忆文件路径 `memory_file = Path(workspace_dir) / ".agent_memory.json"`。
+10. 初始化工具列表，包含普通工具和记忆工具：
+   - `ReadTool`、`WriteTool`、`BashTool`
+   - `SessionNoteTool(memory_file=...)`
+   - `RecallNoteTool(memory_file=...)`
+
+执行流程（会话 1）：
+1. 打印会话 1 标题：目标是“教会 Agent 用户偏好并要求记住”。
+2. 创建第一个 Agent 实例 `agent1`：
+   - `max_steps=15`，给更高步骤预算以容纳“理解+记录+写文件”。
+3. 构造 `task1`：包含用户身份、项目、技术栈、编码偏好，并明确要求“记住这些信息”，同时创建 `README.md`。
+4. `agent1.add_user_message(task1)` 后执行 `await agent1.run()`。
+5. 运行成功后：
+   - 打印 Agent 回复。
+   - 检查 `memory_file` 是否存在。
+   - 若存在，读取 JSON 并打印“记录条目数量+摘要”；不存在则给出提醒。
+6. 若异常，打印错误并 `return` 提前结束该 Demo。
+
+执行流程（会话 2）：
+1. 打印会话 2 标题：用新实例模拟“新的对话轮次”。
+2. 创建第二个 Agent 实例 `agent2`（不是复用 `agent1`），`max_steps=10`。
+3. 发送 `task2`：询问“你还记得我是谁、在做什么项目、编码风格偏好吗”。
+4. 执行 `await agent2.run()`。
+5. 运行成功后打印回复，并总结关键结论：
+   - 会话 1 记录了重要信息。
+   - 会话 2 通过记忆工具恢复信息。
+   - 持久化媒介是共享的记忆文件，而不是进程内变量。
+6. 异常则打印错误。
+
+这个函数的核心演示点：
+- “跨会话记忆”依赖外部持久化文件，而不是单个 Agent 实例生命周期。
+- 只要新 Agent 使用同一 `memory_file` 并拥有 recall 工具，就能恢复上下文。
+
+---
+
+## `async def main()`
+
+函数职责：统一编排两个 Demo 的执行顺序。
+
+执行流程：
+1. 打印总标题和说明，强调 Session Notes 的价值。
+2. 顺序执行：
+   - `await demo_direct_note_usage()`
+   - 打印空行
+   - `await demo_agent_with_notes()`
+3. 打印“全部完成”提示。
+
+设计意图：
+- 先讲“工具级能力”（直接调用），再讲“Agent 级能力”（跨会话协作）。
+
+---
+
+## `if __name__ == "__main__":`
+
+函数职责：脚本入口控制。
+
+执行流程：
+1. 仅当该文件被直接运行时，执行 `asyncio.run(main())`。
+2. 如果该文件被 import，不会自动运行 Demo。
+
+---
+
+## 这份示例体现的工程模式
+
+1. 前置校验模式：配置文件和 API key 先校验，减少运行时歧义。
+2. 隔离模式：临时工作区和临时记忆文件让示例可重复执行且无残留。
+3. 提示词约束模式：在系统提示词中显式写入“何时记录/回忆”的行为规范。
+4. 跨实例状态共享模式：通过 `memory_file` 把“记忆状态”从 Agent 实例中解耦。

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -3,10 +3,13 @@
 import asyncio
 import json
 import tempfile
+from contextlib import asynccontextmanager
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
+import mini_agent.tools.mcp_loader as mcp_loader
 from mini_agent.tools.mcp_loader import (
     MCPServerConnection,
     MCPTimeoutConfig,
@@ -252,6 +255,64 @@ class TestMCPServerConnectionTimeout:
             execute_timeout=180.0,
         )
         assert conn._get_execute_timeout() == 180.0
+
+
+@pytest.mark.asyncio
+async def test_disconnect_runs_cleanup_in_connection_owner_task(monkeypatch):
+    """Disconnect should succeed even when called from a different asyncio task."""
+
+    @asynccontextmanager
+    async def fake_stdio_client(_server_params):
+        owner_task = asyncio.current_task()
+        yield object(), object()
+        if asyncio.current_task() is not owner_task:
+            raise RuntimeError("stdio_client exited in a different task")
+
+    class FakeClientSession:
+        def __init__(self, _read_stream, _write_stream):
+            self._owner_task = None
+
+        async def __aenter__(self):
+            self._owner_task = asyncio.current_task()
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            if asyncio.current_task() is not self._owner_task:
+                raise RuntimeError("ClientSession exited in a different task")
+            return False
+
+        async def initialize(self):
+            return None
+
+        async def list_tools(self):
+            return SimpleNamespace(
+                tools=[
+                    SimpleNamespace(
+                        name="fake_tool",
+                        description="fake tool",
+                        inputSchema={},
+                    )
+                ]
+            )
+
+    monkeypatch.setattr(mcp_loader, "stdio_client", fake_stdio_client)
+    monkeypatch.setattr(mcp_loader, "ClientSession", FakeClientSession)
+
+    conn = MCPServerConnection(
+        name="test-owner-task",
+        connection_type="stdio",
+        command="fake-command",
+    )
+
+    assert await conn.connect() is True
+    assert [tool.name for tool in conn.tools] == ["fake_tool"]
+
+    disconnect_task = asyncio.create_task(conn.disconnect())
+    await disconnect_task
+
+    assert disconnect_task.exception() is None
+    assert conn.session is None
+    assert conn.exit_stack is None
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary

This change fixes a shutdown bug in Mini Agent when MCP servers are enabled. Users could hit an error while leaving the interactive session because MCP stdio resources were entered in one asyncio task and later cleaned up from a different task during CLI shutdown.

The user-facing effect was noisy exit-time failures such as `Attempted to exit cancel scope in a different task than it was entered in`, and in some cases the shutdown path could stall while waiting on MCP cleanup. This made normal `exit` or interrupt-based shutdown unreliable whenever stdio MCP servers were active.

The root cause was the MCP loader storing an `AsyncExitStack` directly on the connection object and closing it from whatever task happened to run cleanup. AnyIO task groups and cancel scopes used by the MCP stdio transport require enter and exit to happen in the same task, so that cleanup pattern was unsafe once the CLI control flow moved across task boundaries.

The fix moves each MCP connection lifecycle into a dedicated owner task. That task now opens the transport and session, signals readiness back to the caller, waits for a shutdown event, and then performs teardown itself in the same task context that created the AnyIO resources. Disconnect now signals shutdown and waits with a bounded timeout, and global cleanup isolates failures per connection so one bad server cannot break the entire exit path.

## Validation

I added a regression test that simulates a same-task-only transport and session, then verifies that `disconnect()` still succeeds when triggered from a different asyncio task. I also reran the MCP unit coverage for config validation, timeout behavior, and the new cleanup regression.

- `./.venv/bin/pytest tests/test_mcp.py -k "TestDetermineConnectionType or TestMCPServerConnectionInit or TestMCPTimeoutConfig or TestMCPServerConnectionTimeout or url_config_validation or stdio_config_validation or mixed_config_loading or owner_task" -q`

I also re-ran the interactive CLI with MCP enabled and confirmed the shutdown path now reaches `Cleanup complete` without reproducing the AnyIO cross-task cleanup error.
